### PR TITLE
Make source more explicit in the button that redirects to source website

### DIFF
--- a/app/frontend/templates/results_as_list.html
+++ b/app/frontend/templates/results_as_list.html
@@ -47,7 +47,7 @@
 <div class="row">
   <div class="col-xs-12">
     <p class="pull-right links">
-      <a href="{{ result.meta.original_object_urls.html }}" target="_blank" class="visible-xs-block visible-sm-block visible-lg-block visible-md-block">{{ result.source }} <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></a>
+      <a href="{{ result.meta.original_object_urls.html }}" target="_blank" class="visible-xs-block visible-sm-block visible-lg-block visible-md-block">Bron: {{ result.source }} <i class="fa fa-external-link"></i></span></a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
Replace "facebook" with "Bron: facebook" and a font-awesome external link icon.